### PR TITLE
feature: added disable sandbox option to support minimal ci environments

### DIFF
--- a/src/arguments/arguments.ts
+++ b/src/arguments/arguments.ts
@@ -48,6 +48,10 @@ export const argv = yargs(hideBin(process.argv))
         describe: 'Disables telemetry data collection.',
         type: 'boolean',
     })
+    .option('disable-sandbox', {
+        describe: 'run chrome with the --no-sandbox flag. Needed in certain ci environments that lack normal sandboxing capabilities',
+        type: 'boolean',
+    })
     .version('version', 'Show version number', version)
     .alias('version', 'v')
     .example([

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -59,7 +59,13 @@ export async function runHeadlessBrowserAndExportSVG(server: Server, argv: any) 
             }
         })
     }
-    const browser = await puppeteer.launch({ headless: "new" });
+    const noSandbox = (argv as any).disableSandbox || false;
+    const launchArgs = [];
+    if (noSandbox) {
+        launchArgs.push("--no-sandbox");
+    }
+
+    const browser = await puppeteer.launch({ headless: "new", args: launchArgs });
     const page = await browser.newPage();
     const ci = (argv as any).ci || false
     const PORT = (argv as any).rendererPort || 3000


### PR DESCRIPTION
Exposed chrome's no-sandbox argument as disable-sandbox. Useful for minimal environments such as minimal containerized environments.