### PR TITLE
Clearer error message when no resources detected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,12 @@ const runTerraformCommands = async () => {
         console.error(`${graphStderr}`);
         process.exit(1);
     }
+    if (graphStdout.split("\n").length < 10 && graphStdout.match(/.+subgraph\s*"root"\s*{\s*}.*/gs)) {
+        //Empty graph
+        console.error("No valid Terraform resources found in graph.")
+        console.error("Please ensure that you have run Inkdrop inside your Terraform project directory, or specify the path to your Terraform project using the --path argument.")
+        process.exit(1);
+    }
 
     graph = graphStdout
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -20,8 +20,7 @@ async function performActionsToDownloadFile(page: Page) {
         if (selectAllButton) {
             await selectAllButton.click();
         } else {
-            console.error("No valid Terraform resources found in graph.")
-            console.error("Please ensure that you have run Inkdrop inside your Terraform project directory, or specify the path to your Terraform project using the --path argument.")
+            console.warn("Empty diagram detected. No SVG will be created.")
             process.exit(1)
         }
         await page.mouse.click(400, 0, { button: 'right' });


### PR DESCRIPTION
#44 
Differentiate feedback between an empty terraform graph (likely the user is not running inkdrop on a valid TF dir), and no resources found in the Inkdrop diagram (which could happen for multiple reasons)