### PR TITLE
Allow plugin to work on bitbucket.org

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -10,12 +10,14 @@
     "scripting"
   ],
   "host_permissions": [
-    "https://github.com/*"
+    "https://github.com/*",
+    "https://bitbucket.org/*"
   ],
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/*"
+        "https://github.com/*",
+        "https://bitbucket.org/*"
       ],
       "js": [
         "js/diagramScript.js"


### PR DESCRIPTION
This is a small tweak in an attempt to make the plugin work on `bitbucket.org`.